### PR TITLE
Add signature search

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Copyrights: 2025 Alberto Magno <alberto.magno@gmail.com>
 LICENSE GNU General Public License v3.0
 
 # Description: 
-A script that extracts DBKey and decrypt all SQLITE3 database files (including db and write-ahead-logfiles ). 
-At final a ZIP file containing all WhatsAppDesk local state decripted and a SHA512 is calculated.
+A script that extracts DBKey and decrypts all SQLITE3 database files (including db and write-ahead-logfiles ). 
+On completion a ZIP file containing all WhatsApp  decrypted LocalState db's and a SHA512 is calculated.
 Some information also in: https://medium.com/@alberto.magno/whatsapp-desktop-and-web-live-forensics-4n6-233f640e9fb3
 
-Technique based on reverse-engineering-fu (yes! you do not need to use SQLITE3 SEE to decrypt) and some infos contained in following paper:
+Technique based on reverse-engineering-fu (yes! you do not need to use SQLite3 SEE to decrypt) and some info contained in following paper:
 Giyoon Kim, Uk Hur, Soojin Kang, Jongsung Kim,Analyzing the Web and UWP versions of WhatsApp for digital forensics,
 Forensic Science International: Digital Investigation,Volume 52,2025,301861,ISSN 2666-2817,
 https://doi.org/10.1016/j.fsidi.2024.301861.
@@ -27,28 +27,59 @@ https://doi.org/10.1016/j.fsidi.2024.301861.
 
 # Operation:
 - First, it obtains the OfflineDeviceUniqueID, indicating the method used (TPM, REGISTRY, etc...), used in keys derivation linked to the machine.
-- The tool start copying WhatsApp localstate files (where SQLITE3 DB files are located) to operate them
-- It generates the userKey to generate the dbKey for decryption files.
-- DbKey is used to decript DB and WAL files.
-- All files decripted and the other in localstate are compacted.
-- HASH file is generates for chain-of-custody purposes.
+- The tool copies the WhatsApp localstate files (where SQLite3 DB files are located) to operate them
+- It generates the userKey to generate the dbKey for decrypting the files.
+- DbKey is used to decrypt DB and WAL files.
+- All decrypted files and the other content of LocalState are zipped.
+- SHA512 HASH file is generates for chain-of-custody purposes.
 
 This script uses Bouncy Castle (BC) for C# .NET (MIT License).
 https://www.bouncycastle.org/
-OBS: this version needs that target machine be on to have access to the unique device id. Its not possible to decript without this ID.
-You can just collect this ID and DB and nodb files to decrypt in other machine.
+OBS: this version needs that target machine be on to have access to the unique device id. Its not possible to decrypt without this ID.
+
+You can just collect this ID and LocalState contents to decrypt on another machine.
 
 # Usage:
 FIRST OF ALL!
-- It is necessary to unblock BC`s DLL in windows. BouncyCastle.Cryptography.dll must be in the same directory of the ZAPiXWEB.ps1 file.
-  Similar process as decribed for other DLL in https://simpledns.plus/kb/206-how-to-unblock-downloaded-plug-in-dll-file
-- It also necessary to enable unrestricted execution in powershell with the following command typed on PS console:
+- It is necessary to unblock BouncyCastle.Cryptography.dll in Windows. BouncyCastle.Cryptography.dll must be in the same directory of the ZAPiXWEB.ps1 file.
+- It also necessary to enable set the execution policy to Unrestricted in PowerShell to execute the script. This can be done with the following command in PS console:
   
   `Set-ExecutionPolicy Unrestricted`
-- Open PowerShell on target computer (it will claim administrative rights).
+- Open PowerShell on target computer (it will attempt to claim administrative rights).
 run script:
 
   `.\ZAPiXDESK.ps1`
+
+This script will take the following arguments:
+```
+-WhatsAppPath  
+```
+- This should be the full file path to the location of the WhatsApp LocalState directory. If not provided, it will be derived from the running machine's
+  installation of WhatsApp.
+
+```
+-Offline  
+```
+- This will allow you to run the script offline against an extracted WhatsApp directory, provided you have the ODUID. To get this, you can either:
+  - Run the script simply with the `-GetID` flag
+  - Use the binary in the `binaries` folder to run on the live system containing the desired WhatsApp installation;
+  - Check the registry of the running system at `HKLM\SYSTEM\CurrentControlSet\Services\TPM\ODUID` for a value named `RandomSeed`. Using this, you can 
+    convert the value "cv1g1gv" to UTF-16 bytes, then make sure the RandomSeed is in bytes, concatenate the "cvgv1gv" bytes and RandomSeed bytes, then 
+    get the byte value of performing a SHA256 of those bytes.; or
+  - Reboot the computer and boot into UEFI shell, and run the command `dmpstore -b OfflineUniqueIDRandomSeed` and perform the same byte conversion, concat
+    and SHA256 as in the previous step
+
+```
+-ID
+```
+- When using Offline mode, provide the OfflineDeviceUniqueID (ODUID) value as a standard hex string to be used to decrypt database contents on a system other
+  than the original live system
+
+```
+-GetID
+```
+- This will get only the ODUID as a hex string for use in offline decryption.
+
 
 Have a nice 4N6!
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can just collect this ID and LocalState contents to decrypt on another machi
 
 # Usage:
 FIRST OF ALL!
-- It is necessary to unblock BouncyCastle.Cryptography.dll in Windows. BouncyCastle.Cryptography.dll must be in the same directory of the ZAPiXWEB.ps1 file.
+- It is necessary to unblock BouncyCastle.Cryptography.dll in Windows. BouncyCastle.Cryptography.dll must be in the same directory of the ZAPiXDESK.ps1 file.
 - It may also be necessary to enable set the execution policy to Unrestricted or Bypass in PowerShell to execute the script. This can be done with the following command in PS console:
   
   `Set-ExecutionPolicy Unrestricted` or `Set-ExecutionPolicy Bypass`

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ You can just collect this ID and LocalState contents to decrypt on another machi
 # Usage:
 FIRST OF ALL!
 - It is necessary to unblock BouncyCastle.Cryptography.dll in Windows. BouncyCastle.Cryptography.dll must be in the same directory of the ZAPiXWEB.ps1 file.
-- It also necessary to enable set the execution policy to Unrestricted in PowerShell to execute the script. This can be done with the following command in PS console:
+- It may also be necessary to enable set the execution policy to Unrestricted or Bypass in PowerShell to execute the script. This can be done with the following command in PS console:
   
-  `Set-ExecutionPolicy Unrestricted`
+  `Set-ExecutionPolicy Unrestricted` or `Set-ExecutionPolicy Bypass`
 - Open PowerShell on target computer (it will attempt to claim administrative rights).
 run script:
 
-  `.\ZAPiXDESK.ps1`
+  `.\ZAPiXDESK.ps1` with selected arguments. If no arguments are supplied, defaults will be used.
 
 This script will take the following arguments:
 ```
@@ -56,6 +56,11 @@ This script will take the following arguments:
 ```
 - This should be the full file path to the location of the WhatsApp LocalState directory. If not provided, it will be derived from the running machine's
   installation of WhatsApp.
+
+```
+-OutputPath
+```
+- Allows you to select the OutputPath. If not chosen, it will output into the directory from where the script is executed.
 
 ```
 -Offline  

--- a/ZAPiXDESK.ps1
+++ b/ZAPiXDESK.ps1
@@ -4,37 +4,28 @@ param (
     [Parameter(Mandatory = $false)]
     [switch]$Offline,
     [Parameter(Mandatory = $false)]
-    [string]$ID
+    [string]$ID,
+    [Parameter(Mandatory = $false)]
+    [switch]$GetID
 )
 
-Clear-Host
-Write-Output "______  ___  ______ ___   _______ _____ _____ _   __
-|___  / / _ \ | ___ (_) \ / /  _  \  ___/  ___| | / /
-   / / / /_\ \| |_/ /_ \ V /| | | | |__ \ `--.| |/ / 
-  / /  |  _  ||  __/| |/   \| | | |  __| `--. \    \ 
-./ /___| | | || |   | / /^\ \ |/ /| |___/\__/ / |\  \
-\_____/\_| |_/\_|   |_\/   \/___/ \____/\____/\_| \_/
-                                       ZAPiXDESK         
-# Copyright: 2025 Alberto Magno <alberto.magno@gmail.com> 
-# URL: https://github.com/kraftdenker/ZAPiXDESK"                                      
-
 # Windows WhatsApp Desktop
-# Script Name: SPIZAPIXWEB.js
-# Version: 1.0
-# Revised Date: 01/01/25
+# Version: 2.0
+# Revised Date: 04/12/25
+# Revised by: Corey Forman (digitalsleuth)
 
 # Copyright: 2025 Alberto Magno <alberto.magno@gmail.com> 
 # URL: https://github.com/kraftdenker/ZAPiXDESK
 
-# Description: A script that extracts DBKey and decrypt all SQLITE3 database files (including db and write-ahead-logfiles ). At final a ZIP file containing all WhatsAppDesk localstate decripted.
+# Description: A script that extracts DBKey and decrypt all SQLite3 database files (including db and write-ahead-logfiles ). At final a ZIP file containing all WhatsAppDesk localstate decripted.
 
-# Technique based on reverse-engineering-fu (yes! you do not need to use SQLITE3 SEE to decrypt) and infos contained in following paper:
+# Technique based on reverse-engineering-fu (yes! you do not need to use SQLite3 SEE to decrypt) and infos contained in following paper:
 # Giyoon Kim, Uk Hur, Soojin Kang, Jongsung Kim,Analyzing the Web and UWP versions of WhatsApp for digital forensics,
 # Forensic Science International: Digital Investigation,Volume 52,2025,301861,ISSN 2666-2817,
 # https://doi.org/10.1016/j.fsidi.2024.301861.
 # (https://www.sciencedirect.com/science/article/pii/S2666281724001884)
 
-# Updates: 10 April 2025 - Corey Forman @digitalsleuth
+# Updates: 12 April 2025 - Corey Forman @digitalsleuth
 # The following signatures were observed before each of the values during analysis of multiple
 # nondb_settings dat files
 # dpapi_blob signature: 02010430. If the next byte is not 81 or 82, Then skip that and 2 more bytes and read the right nibble of the 4th byte to 
@@ -69,7 +60,7 @@ $global:reverseDate = Get-Date -Format "yyyyMMddHHmmss"
 $global:targetOutput="$currentDirectory\ZAPiXDESK_$reverseDate"
 $global:userKey = [byte[]]::new(32)
 $global:whatsappDll_passphrase = "5303b14c0984e9b13fe75770cd25aaf7"
-
+$global:ZDVersion = "2.0.0"
 function Convert-HexStringToByteArray {
     param (
         [string]$hexString
@@ -722,6 +713,18 @@ function Start-ZapixDesk {
         [Parameter(Mandatory = $false)]
         [string]$ID
     )
+    Clear-Host
+    Write-Output "
+______  ___  ______ ___   _______ _____ _____ _   __
+|___  / / _ \ | ___ (_) \ / /  _  \  ___/  ___| | / /
+   / / / /_\ \| |_/ /_ \ V /| | | | |__ \ ---.| |/ /
+  / /  |  _  ||  __/| |/   \| | | |  __| ---. \    \
+./ /___| | | || |   | / /^\ \ |/ /| |___/\__/ / |\  \
+\_____/\_| |_/\_|   |_\/   \/___/ \____/\____/\_| \_/
+                                       ZAPiXDESK         
+# Copyright: 2025 Alberto Magno <alberto.magno@gmail.com> 
+# URL: https://github.com/kraftdenker/ZAPiXDESK
+# Version: $ZDVersion"
     if (-not $PSBoundParameters.ContainsKey('WhatsAppPath'))
     {
         $WhatsAppPath = Get-AppLocalStatePath -AppName "WhatsApp"
@@ -836,7 +839,12 @@ if ($PSBoundParameters.ContainsKey('Offline'))
         exit
     }
     Start-ZapixDesk -WhatsAppPath $WhatsAppPath -Offline -ID $ID
-} else {
+} elseif ($PSBoundParameters.ContainsKey('GetID')){
+    $ODUID = Get-OfflineDeviceUniqueID -Salt "0x6300760031006700310067007600"
+    $ODUID_HEX = ConvertTo-HexString $ODUID.ID
+    Write-Output "ODUID: $ODUID_HEX"
+}
+else {
     if (-not $PSBoundParameters.ContainsKey('WhatsAppPath'))
     {
         $WhatsAppPath = Get-AppLocalStatePath -AppName "WhatsApp"


### PR DESCRIPTION
This PR will:

- Add a File Signature search (file signatures identified through research over multiple WA instances)
- Add a Windows compiled binary to search for the ODUID for testing purposes (based on the original research)
- Adds a Start-Zapixdesk function and parameters which will allow for customizable online/offline options and specific source file paths
- Removes a couple of, but not all, unused functions to centralize all key extractions processes though a single function (Get-Key)